### PR TITLE
Improve docstring for sort_cameras_by_filename

### DIFF
--- a/preprocess/metrics.py
+++ b/preprocess/metrics.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def sort_cameras_by_filename(reconstruction):
     """
-    Sort cameras in the reconstruction by their filename.
+    Sort images in the reconstruction by their filename and return their IDs.
     
     Parameters:
         reconstruction: A reconstruction object with an 'images' attribute.


### PR DESCRIPTION
## Summary
- clarify that images are sorted by filename in the `sort_cameras_by_filename` docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a48f4b9c832a9d570987abee8031