### PR TITLE
Support processing image folders in pipeline

### DIFF
--- a/do_all.py
+++ b/do_all.py
@@ -17,6 +17,7 @@ import os
 import sys
 import shutil
 import time
+import shlex
 from argparse import ArgumentParser
 
 # Get the current script directory
@@ -71,7 +72,7 @@ def run_command(command, error_message):
     return True
 
 
-def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=False):
+def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=False, images_path=None):
     """
     Process a single video through the entire pipeline.
     
@@ -119,8 +120,11 @@ def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=
     # Step 1: Extract frames and perform SfM
     if not (os.path.isdir(images_p) and os.path.isdir(sparse_p)) or clean:
         print("\n--- Step 1: Frame extraction and Structure from Motion ---")
-        sfm_command = f"python preprocess/main_video_process.py -s {source_p} -n {n_frames} --robust"
-        
+        sfm_command = f"python preprocess/main_video_process.py -s {shlex.quote(source_p)} -n {n_frames} --robust"
+
+        if images_path:
+            sfm_command += f" --image_input {shlex.quote(images_path)}"
+
         if clean:
             sfm_command += " -c"
         if minimal:
@@ -191,28 +195,36 @@ def main(args):
     minimal = args.minimal
     full = args.full
     full_res = args.full_res
-    
+    images_path = args.images_path
+
     if not os.path.exists(source_p):
         print(f"Error: Source path {source_p} does not exist")
         return
-    
+
+    if images_path and not os.path.isdir(images_path):
+        print(f"Error: Image path {images_path} does not exist or is not a directory")
+        return
+
+    if args.all and images_path:
+        print("Warning: --images_path was provided together with --all. The same images folder will be used for each subdirectory.")
+
     if not args.all:
         # Process a single video
-        do_one(source_p, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res)
+        do_one(source_p, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res, images_path=images_path)
     else:
         # Process all subdirectories
         print(f"Processing all subdirectories in {source_p}")
         dirs = os.listdir(source_p)
         successful = 0
         failed = 0
-        
+
         for d in dirs:
             tmp = os.path.join(source_p, d)
             if not os.path.isdir(tmp):
                 continue
-                
+
             print(f"\nProcessing directory: {d}")
-            result = do_one(tmp, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res)
+            result = do_one(tmp, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res, images_path=images_path)
             
             if result:
                 successful += 1
@@ -237,6 +249,8 @@ if __name__ == '__main__':
                         help="Extract final frames at full resolution")
     parser.add_argument("--all", "-a", action='store_true',
                         help="Process all subdirectories in the source path")
+    parser.add_argument("--images_path", type=str, default=None,
+                        help="Optional path to a folder of images to use directly instead of extracting from a video")
     
     args = parser.parse_args()
     main(args)

--- a/preprocess/colmap_pipeline.py
+++ b/preprocess/colmap_pipeline.py
@@ -12,6 +12,119 @@ import logging
 import pycolmap
 from typing import Dict, List, Tuple, Set, Optional
 
+
+class ImageFolderWrapper:
+    """Lightweight wrapper that mimics :class:`FFmpegWrapper` for image folders."""
+
+    def __init__(self, source_path: str, image_dir: str, output_dir: str):
+        self.source_path = source_path
+        self.image_dir = image_dir
+        self.output_dir = output_dir
+        self.tmp_path = os.path.join(source_path, "tmp")
+        os.makedirs(self.tmp_path, exist_ok=True)
+        self._prepare_tmp_frames()
+
+    def _prepare_tmp_frames(self):
+        supported_ext = {".jpg", ".jpeg", ".png"}
+        if not os.path.isdir(self.image_dir):
+            raise FileNotFoundError(f"Image directory {self.image_dir} does not exist")
+
+        images = [
+            f for f in os.listdir(self.image_dir)
+            if os.path.splitext(f)[1].lower() in supported_ext
+            and os.path.isfile(os.path.join(self.image_dir, f))
+        ]
+        images.sort()
+
+        if not images:
+            raise RuntimeError(f"No images with extensions {supported_ext} found in {self.image_dir}")
+
+        # Clean previous temporary frames
+        for item in os.listdir(self.tmp_path):
+            tmp_item = os.path.join(self.tmp_path, item)
+            if os.path.isdir(tmp_item):
+                shutil.rmtree(tmp_item)
+            else:
+                os.unlink(tmp_item)
+
+        self.frames = []
+        self.index_to_name = {}
+        for index, filename in enumerate(images, start=1):
+            ext = os.path.splitext(filename)[1].lower()
+            new_name = f"{index:08d}{ext}"
+            src = os.path.join(self.image_dir, filename)
+            dst = os.path.join(self.tmp_path, new_name)
+            if os.path.exists(dst):
+                os.remove(dst)
+            try:
+                os.symlink(src, dst)
+            except OSError:
+                shutil.copy2(src, dst)
+            self.frames.append(new_name)
+            self.index_to_name[index] = new_name
+
+        self.duration = float(len(self.frames))
+
+    def get_list_of_n_frames(self, n: int, start_frame=None, end_frame=None) -> List[str]:
+        if not self.frames or n <= 0:
+            return []
+
+        def _normalize(frame):
+            if frame is None:
+                return None
+            if isinstance(frame, int):
+                return self.index_to_name.get(frame)
+            return frame
+
+        start_frame = _normalize(start_frame)
+        end_frame = _normalize(end_frame)
+
+        start_idx = self.frames.index(start_frame) if start_frame in self.frames else 0
+        end_idx = self.frames.index(end_frame) if end_frame in self.frames else len(self.frames) - 1
+
+        valid_frames = self.frames[start_idx:end_idx + 1]
+        total_frames = len(valid_frames)
+
+        if n >= total_frames:
+            return [os.path.join(self.tmp_path, frame) for frame in valid_frames]
+
+        step = total_frames / n
+        indices = sorted(set(round(i * step) for i in range(n)))
+        selected_frames = [valid_frames[i] for i in indices if i < total_frames]
+        return [os.path.join(self.tmp_path, frame) for frame in selected_frames]
+
+    def extract_specific_frames(self, frame_indices, full_res=False):
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        # Remove existing extracted frames to avoid stale images
+        for item in os.listdir(self.output_dir):
+            item_path = os.path.join(self.output_dir, item)
+            if os.path.isfile(item_path) or os.path.islink(item_path):
+                os.remove(item_path)
+
+        for idx in frame_indices:
+            try:
+                frame_index = int(idx)
+            except (ValueError, TypeError):
+                continue
+            name = self.index_to_name.get(frame_index)
+            if not name:
+                continue
+            src = os.path.join(self.tmp_path, name)
+            if not os.path.exists(src):
+                continue
+            dst = os.path.join(self.output_dir, name)
+            if os.path.exists(dst):
+                os.remove(dst)
+            shutil.copy2(src, dst)
+
+    def ind_to_frame_name(self, ind: int) -> str:
+        frame_index = int(ind)
+        name = self.index_to_name.get(frame_index)
+        if not name:
+            name = f"{frame_index:08d}.jpeg"
+        return os.path.join(self.tmp_path, name)
+
 from utils import _name_to_ind, make_folders, clean_paths
 from metrics import compute_overlaps_in_rec, sort_cameras_by_filename, overlap_between_two_images
 
@@ -183,7 +296,7 @@ def reconstruct(source_path, db_path, image_path, output_path, image_list, exist
     return rec, image_list, reconstructions
 
 
-def iterative_reconstruc(source_path, db_path, image_path, output_path, image_list, fmw, video_n, max_iter=15):
+def iterative_reconstruc(source_path, db_path, image_path, output_path, image_list, fmw, video_n, max_iter=15, extra_keep=None):
     """
     Iteratively attempt reconstruction by gradually increasing the number of frames.
     
@@ -209,7 +322,7 @@ def iterative_reconstruc(source_path, db_path, image_path, output_path, image_li
     # increase until we get at least 50% ratio of reconstructed images 
 
     while rec is None and itr < max_iter:
-        clean_paths(source_path, video_n, db_path)
+        clean_paths(source_path, video_n, db_path, extra_keep=extra_keep)
         make_folders(source_path)
 
         # Check percentage reconstructed
@@ -523,19 +636,43 @@ def interpolate_all_frames(rec, fmw):
     
     return all_poses
 
-def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100):
+def _compute_extra_keep(source_path: str, image_input: Optional[str]) -> List[str]:
+    if not image_input:
+        return []
+
+    extra_keep = []
+    abs_source = os.path.abspath(source_path)
+    abs_images = os.path.abspath(image_input)
+
+    try:
+        common = os.path.commonpath([abs_source, abs_images])
+    except ValueError:
+        return []
+
+    if common == abs_source:
+        rel = os.path.relpath(abs_images, abs_source)
+        if rel != os.curdir:
+            top_level = rel.split(os.sep)[0]
+            extra_keep.append(top_level)
+
+    return extra_keep
+
+
+def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100, image_input=None):
     """
-    Main pipeline function to process a video, perform reconstruction,
+    Main pipeline function to process an input sequence, perform reconstruction,
     and generate undistorted outputs.
-    
+
     Parameters:
-        source_path (str): Base directory containing video and images.
+        source_path (str): Base directory containing the dataset.
         n_images (int): Target number of images for reconstruction.
         clean (bool, optional): Flag to clean existing paths before processing.
         minimal (bool, optional): Use minimal frame selection after final reconstruction.
         full (bool, optional): Use all frame selection after final reconstruction.
         full_res (bool, optional): Extract final frames at full resolution.
         average_overlap (int, optional): Target average overlap between frames.
+        image_input (str, optional): Path to a directory of input images. When provided,
+            frame extraction from video is skipped and the images are used directly.
     """
     files_n = os.listdir(source_path)
     video_n = None
@@ -544,22 +681,28 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
             video_n = f
             break
 
-    if video_n is None and (not ("input" in files_n)):
-        exit(1)
+    if video_n is None and image_input is None and ("input" not in files_n):
+        raise RuntimeError("No video file found and no image input provided.")
 
-    video_p = os.path.join(source_path, video_n)
     input_p = os.path.join(source_path, 'input')
     distorted_path = os.path.join(source_path, "distorted")
     distorted_sparse_path = os.path.join(distorted_path, "sparse")
     distorted_sparse_final_path = os.path.join(distorted_path, "sparse_final")
     sparse_path = os.path.join(source_path, "sparse/0")
     db_path = os.path.join(distorted_path, "database.db")
+    extra_keep = _compute_extra_keep(source_path, image_input)
+
     if clean:
-        clean_paths(source_path, video_n, db_path)
+        clean_paths(source_path, video_n, db_path, extra_keep=extra_keep)
     make_folders(source_path)
 
-    from video_processing import FFmpegWrapper
-    fmw = FFmpegWrapper(video_p, input_p)
+    if image_input:
+        fmw = ImageFolderWrapper(source_path, image_input, input_p)
+        video_p = None
+    else:
+        from video_processing import FFmpegWrapper
+        video_p = os.path.join(source_path, video_n)
+        fmw = FFmpegWrapper(video_p, input_p)
 
     n_frames = int(fmw.duration)
     frames_list = fmw.get_list_of_n_frames(n_frames)
@@ -569,7 +712,16 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
         rec = pycolmap.Reconstruction(os.path.join(distorted_path, "orig_distorted"))
         frames_list = [os.path.join(fmw.tmp_path, rec.images[i].name) for i in rec.images]
     else:
-        rec, frames_list = iterative_reconstruc(source_path, db_path, fmw.tmp_path, distorted_sparse_path, frames_list, fmw, video_n)
+        rec, frames_list = iterative_reconstruc(
+            source_path,
+            db_path,
+            fmw.tmp_path,
+            distorted_sparse_path,
+            frames_list,
+            fmw,
+            video_n,
+            extra_keep=extra_keep,
+        )
         rec.write_binary(distorted_sparse_path)
         shutil.copytree(distorted_sparse_path, os.path.join(os.path.dirname(distorted_sparse_path), "orig_distorted"))
     
@@ -660,9 +812,9 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
 
 def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100,
                  random_ratio=0.2, pruning_threshold=0.05, coverage_weight=0.4, triangulation_weight=0.3,
-                 diversity_weight=0.2, confidence_weight=0.1):
+                 diversity_weight=0.2, confidence_weight=0.1, image_input=None):
     """
-    Enhanced pipeline function to process a video, perform reconstruction with robust frame selection,
+    Enhanced pipeline function to process an input sequence, perform reconstruction with robust frame selection,
     and generate undistorted outputs. This version uses camera pose interpolation to make better
     decisions about which frames to include.
     
@@ -680,6 +832,8 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
         triangulation_weight (float, optional): Weight for triangulation score in frame selection.
         diversity_weight (float, optional): Weight for diversity score in frame selection.
         confidence_weight (float, optional): Weight for confidence score in frame selection.
+        image_input (str, optional): Path to a directory of input images. When provided,
+            frame extraction from video is skipped and the images are used directly.
     """
     files_n = os.listdir(source_path)
     video_n = None
@@ -688,23 +842,29 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
             video_n = f
             break
 
-    if video_n is None and (not ("input" in files_n)):
-        exit(1)
+    if video_n is None and image_input is None and ("input" not in files_n):
+        raise RuntimeError("No video file found and no image input provided.")
 
-    video_p = os.path.join(source_path, video_n)
     input_p = os.path.join(source_path, 'input')
     distorted_path = os.path.join(source_path, "distorted")
     distorted_sparse_path = os.path.join(distorted_path, "sparse")
     distorted_sparse_final_path = os.path.join(distorted_path, "sparse_final")
     sparse_path = os.path.join(source_path, "sparse/0")
     db_path = os.path.join(distorted_path, "database.db")
-    
+
+    extra_keep = _compute_extra_keep(source_path, image_input)
+
     if clean:
-        clean_paths(source_path, video_n, db_path)
+        clean_paths(source_path, video_n, db_path, extra_keep=extra_keep)
     make_folders(source_path)
 
-    from video_processing import FFmpegWrapper
-    fmw = FFmpegWrapper(video_p, input_p)
+    if image_input:
+        fmw = ImageFolderWrapper(source_path, image_input, input_p)
+        video_p = None
+    else:
+        from video_processing import FFmpegWrapper
+        video_p = os.path.join(source_path, video_n)
+        fmw = FFmpegWrapper(video_p, input_p)
 
     n_frames = int(fmw.duration)
     frames_list = fmw.get_list_of_n_frames(n_frames)
@@ -715,7 +875,16 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
         rec = pycolmap.Reconstruction(os.path.join(distorted_path, "orig_distorted"))
         frames_list = [os.path.join(fmw.tmp_path, rec.images[i].name) for i in rec.images]
     else:
-        rec, frames_list = iterative_reconstruc(source_path, db_path, fmw.tmp_path, distorted_sparse_path, frames_list, fmw, video_n)
+        rec, frames_list = iterative_reconstruc(
+            source_path,
+            db_path,
+            fmw.tmp_path,
+            distorted_sparse_path,
+            frames_list,
+            fmw,
+            video_n,
+            extra_keep=extra_keep,
+        )
         rec.write_binary(distorted_sparse_path)
         shutil.copytree(distorted_sparse_path, os.path.join(os.path.dirname(distorted_sparse_path), "orig_distorted"))
     

--- a/preprocess/main_video_process.py
+++ b/preprocess/main_video_process.py
@@ -18,6 +18,7 @@ def main(args):
     clean = args.clean
     full = args.full
     full_res = args.full_res
+    image_input = args.image_input
     
     if args.robust:
         print("Using robust reconstruction pipeline...")
@@ -34,11 +35,12 @@ def main(args):
             coverage_weight=args.coverage_weight,
             triangulation_weight=args.triangulation_weight,
             diversity_weight=args.diversity_weight,
-            confidence_weight=args.confidence_weight
+            confidence_weight=args.confidence_weight,
+            image_input=image_input
         )
     else:
         print("Using standard reconstruction pipeline...")
-        do_one(source_path, n_images, clean, minimal=args.minimal, full=full, full_res=full_res)
+        do_one(source_path, n_images, clean, minimal=args.minimal, full=full, full_res=full_res, image_input=image_input)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="COLMAP reconstruction pipeline for video processing")
@@ -56,6 +58,8 @@ if __name__ == '__main__':
                         help="Extract final frames at full resolution")
     parser.add_argument("--robust", "-r", action='store_true',
                         help="Use robust reconstruction pipeline with pose interpolation")
+    parser.add_argument("--image_input", type=str, default=None,
+                        help="Optional path to an image folder to use instead of extracting frames from a video")
     
     # Additional parameters for the robust pipeline
     parser.add_argument("--random_ratio", type=float, default=0.2,

--- a/preprocess/utils.py
+++ b/preprocess/utils.py
@@ -106,7 +106,7 @@ def make_folders(source_path):
     os.makedirs(sparse_path, exist_ok=True)
     os.makedirs(distorted_sparse_final_path, exist_ok=True)
 
-def clean_paths(source_path, video_n, db_path):
+def clean_paths(source_path, video_n, db_path, extra_keep=None):
     """
     Clean the source directory by removing temporary and unwanted folders.
     
@@ -118,10 +118,12 @@ def clean_paths(source_path, video_n, db_path):
     if os.path.isfile(db_path):
         os.remove(db_path)
     all_files = os.listdir(source_path)
-    if video_n in all_files:
-        all_files.remove(video_n)
-    if "tmp" in all_files:
-        all_files.remove("tmp")
+    keep = set(extra_keep or [])
+    if video_n:
+        keep.add(video_n)
+    keep.add("tmp")
+
+    all_files = [f for f in all_files if f not in keep]
     print(f"Clean start. removing:\n{all_files}")
     paths = [os.path.join(source_path, tmp) for tmp in all_files]
     [shutil.rmtree(tmp) for tmp in paths if os.path.isdir(tmp)]


### PR DESCRIPTION
## Summary
- add a `--images_path` option to `do_all.py` so the pipeline can operate on a folder of images without running frame extraction
- extend the preprocessing entry points to pass the optional image directory through to the COLMAP pipeline
- introduce an `ImageFolderWrapper` and related safeguards in the COLMAP pipeline so image directories can be used in place of videos while preserving existing cleaning behaviour

## Testing
- python -m compileall do_all.py preprocess

------
https://chatgpt.com/codex/tasks/task_e_6907cc1d96ac832aaa3582574cfa74cc