### PR TITLE
Add image sequence support to preprocessing pipeline

### DIFF
--- a/do_all.py
+++ b/do_all.py
@@ -71,7 +71,7 @@ def run_command(command, error_message):
     return True
 
 
-def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=False):
+def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=False, images_path=None):
     """
     Process a single video through the entire pipeline.
     
@@ -88,17 +88,22 @@ def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=
     """
     start_time = time.time()
     
-    # Find video file in the source directory
+    # Find video file in the source directory unless images are provided directly
+    if images_path and not os.path.isdir(images_path):
+        print(f"Error: Image path {images_path} does not exist")
+        return False
+
     files_n = os.listdir(source_p)
     video_n = None
-    for f in files_n:
-        if f.lower().endswith(('.mp4', '.mov', '.avi')):
-            video_n = f
-            break
-    
-    if video_n is None and "input" not in files_n:
-        print(f"Error: No video file found in {source_p}")
-        return False
+    if images_path is None:
+        for f in files_n:
+            if f.lower().endswith(('.mp4', '.mov', '.avi')):
+                video_n = f
+                break
+
+        if video_n is None and "input" not in files_n:
+            print(f"Error: No video file found in {source_p}")
+            return False
     
     # Define output directories
     images_p = os.path.join(source_p, 'images')
@@ -114,12 +119,16 @@ def do_one(source_p, n_frames, clean=False, minimal=False, full=False, full_res=
         duration, frame_count, fps = get_video_length(video_path)
         if duration:
             print(f"Video duration: {duration}s, {frame_count} frames, {fps} FPS")
+    elif images_path:
+        print(f"Using images from: {images_path}")
     print(f"{'='*80}\n")
-    
+
     # Step 1: Extract frames and perform SfM
     if not (os.path.isdir(images_p) and os.path.isdir(sparse_p)) or clean:
         print("\n--- Step 1: Frame extraction and Structure from Motion ---")
         sfm_command = f"python preprocess/main_video_process.py -s {source_p} -n {n_frames} --robust"
+        if images_path:
+            sfm_command += f' --images_path "{images_path}"'
         
         if clean:
             sfm_command += " -c"
@@ -191,14 +200,18 @@ def main(args):
     minimal = args.minimal
     full = args.full
     full_res = args.full_res
-    
+    images_path = args.images_path
+
+    if images_path:
+        images_path = os.path.abspath(images_path)
+
     if not os.path.exists(source_p):
         print(f"Error: Source path {source_p} does not exist")
         return
-    
+
     if not args.all:
         # Process a single video
-        do_one(source_p, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res)
+        do_one(source_p, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res, images_path=images_path)
     else:
         # Process all subdirectories
         print(f"Processing all subdirectories in {source_p}")
@@ -212,7 +225,7 @@ def main(args):
                 continue
                 
             print(f"\nProcessing directory: {d}")
-            result = do_one(tmp, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res)
+            result = do_one(tmp, n_frames, clean=clean, minimal=minimal, full=full, full_res=full_res, images_path=images_path)
             
             if result:
                 successful += 1
@@ -237,6 +250,8 @@ if __name__ == '__main__':
                         help="Extract final frames at full resolution")
     parser.add_argument("--all", "-a", action='store_true',
                         help="Process all subdirectories in the source path")
+    parser.add_argument("--images_path", type=str, default=None,
+                        help="Path to a directory containing pre-extracted images")
     
     args = parser.parse_args()
     main(args)

--- a/preprocess/colmap_pipeline.py
+++ b/preprocess/colmap_pipeline.py
@@ -523,7 +523,7 @@ def interpolate_all_frames(rec, fmw):
     
     return all_poses
 
-def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100):
+def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100, images_path=None):
     """
     Main pipeline function to process a video, perform reconstruction,
     and generate undistorted outputs.
@@ -539,15 +539,16 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
     """
     files_n = os.listdir(source_path)
     video_n = None
-    for f in files_n:
-        if f.lower().endswith(('.mp4', '.mov', '.avi')):
-            video_n = f
-            break
+    if images_path is None:
+        for f in files_n:
+            if f.lower().endswith(('.mp4', '.mov', '.avi')):
+                video_n = f
+                break
 
-    if video_n is None and (not ("input" in files_n)):
-        exit(1)
+        if video_n is None and (not ("input" in files_n)):
+            exit(1)
 
-    video_p = os.path.join(source_path, video_n)
+    video_p = os.path.join(source_path, video_n) if video_n else None
     input_p = os.path.join(source_path, 'input')
     distorted_path = os.path.join(source_path, "distorted")
     distorted_sparse_path = os.path.join(distorted_path, "sparse")
@@ -558,8 +559,11 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
         clean_paths(source_path, video_n, db_path)
     make_folders(source_path)
 
-    from video_processing import FFmpegWrapper
-    fmw = FFmpegWrapper(video_p, input_p)
+    from video_processing import FFmpegWrapper, ImageFolderWrapper
+    if images_path:
+        fmw = ImageFolderWrapper(images_path, input_p)
+    else:
+        fmw = FFmpegWrapper(video_p, input_p)
 
     n_frames = int(fmw.duration)
     frames_list = fmw.get_list_of_n_frames(n_frames)
@@ -660,7 +664,7 @@ def do_one(source_path, n_images, clean=False, minimal=False, full=False, full_r
 
 def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False, full_res=False, average_overlap=100,
                  random_ratio=0.2, pruning_threshold=0.05, coverage_weight=0.4, triangulation_weight=0.3,
-                 diversity_weight=0.2, confidence_weight=0.1):
+                 diversity_weight=0.2, confidence_weight=0.1, images_path=None):
     """
     Enhanced pipeline function to process a video, perform reconstruction with robust frame selection,
     and generate undistorted outputs. This version uses camera pose interpolation to make better
@@ -683,15 +687,16 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
     """
     files_n = os.listdir(source_path)
     video_n = None
-    for f in files_n:
-        if f.lower().endswith(('.mp4', '.mov', '.avi')):
-            video_n = f
-            break
+    if images_path is None:
+        for f in files_n:
+            if f.lower().endswith(('.mp4', '.mov', '.avi')):
+                video_n = f
+                break
 
-    if video_n is None and (not ("input" in files_n)):
-        exit(1)
+        if video_n is None and (not ("input" in files_n)):
+            exit(1)
 
-    video_p = os.path.join(source_path, video_n)
+    video_p = os.path.join(source_path, video_n) if video_n else None
     input_p = os.path.join(source_path, 'input')
     distorted_path = os.path.join(source_path, "distorted")
     distorted_sparse_path = os.path.join(distorted_path, "sparse")
@@ -703,8 +708,11 @@ def do_one_robust(source_path, n_images, clean=False, minimal=False, full=False,
         clean_paths(source_path, video_n, db_path)
     make_folders(source_path)
 
-    from video_processing import FFmpegWrapper
-    fmw = FFmpegWrapper(video_p, input_p)
+    from video_processing import FFmpegWrapper, ImageFolderWrapper
+    if images_path:
+        fmw = ImageFolderWrapper(images_path, input_p)
+    else:
+        fmw = FFmpegWrapper(video_p, input_p)
 
     n_frames = int(fmw.duration)
     frames_list = fmw.get_list_of_n_frames(n_frames)

--- a/preprocess/main_video_process.py
+++ b/preprocess/main_video_process.py
@@ -18,7 +18,8 @@ def main(args):
     clean = args.clean
     full = args.full
     full_res = args.full_res
-    
+    images_path = args.images_path
+
     if args.robust:
         print("Using robust reconstruction pipeline...")
         # Pass additional parameters to the robust pipeline
@@ -29,6 +30,7 @@ def main(args):
             minimal=args.minimal,
             full=full,
             full_res=full_res,
+            images_path=images_path,
             random_ratio=args.random_ratio,
             pruning_threshold=args.pruning_threshold,
             coverage_weight=args.coverage_weight,
@@ -38,7 +40,7 @@ def main(args):
         )
     else:
         print("Using standard reconstruction pipeline...")
-        do_one(source_path, n_images, clean, minimal=args.minimal, full=full, full_res=full_res)
+        do_one(source_path, n_images, clean, minimal=args.minimal, full=full, full_res=full_res, images_path=images_path)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="COLMAP reconstruction pipeline for video processing")
@@ -56,6 +58,8 @@ if __name__ == '__main__':
                         help="Extract final frames at full resolution")
     parser.add_argument("--robust", "-r", action='store_true',
                         help="Use robust reconstruction pipeline with pose interpolation")
+    parser.add_argument("--images_path", type=str, default=None,
+                        help="Optional path to a directory containing pre-extracted images")
     
     # Additional parameters for the robust pipeline
     parser.add_argument("--random_ratio", type=float, default=0.2,

--- a/preprocess/utils.py
+++ b/preprocess/utils.py
@@ -118,7 +118,7 @@ def clean_paths(source_path, video_n, db_path):
     if os.path.isfile(db_path):
         os.remove(db_path)
     all_files = os.listdir(source_path)
-    if video_n in all_files:
+    if video_n and video_n in all_files:
         all_files.remove(video_n)
     if "tmp" in all_files:
         all_files.remove("tmp")

--- a/preprocess/video_processing.py
+++ b/preprocess/video_processing.py
@@ -6,7 +6,8 @@ Contains functionality for video metadata extraction and frame extraction.
 import subprocess
 import os
 import json
-from typing import List, Optional
+import shutil
+from typing import Dict, List, Optional
 
 class FFmpegWrapper:
     """
@@ -147,4 +148,130 @@ class FFmpegWrapper:
         for p1, p2 in peak_pairs:
             if p1 in self.frames and p2 in self.frames:
                 selected_frames.extend(self.get_list_of_n_frames(n, start_frame=p1, end_frame=p2))
+        return selected_frames
+
+
+class ImageFolderWrapper:
+    """Utility that mimics :class:`FFmpegWrapper` for pre-extracted image sequences."""
+
+    _VALID_EXT = (".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp")
+
+    def __init__(self, images_path: str, output_dir: str):
+        self.images_path = images_path
+        self.output_dir = output_dir
+        self.tmp_path = os.path.join(os.path.dirname(output_dir), "tmp")
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(self.tmp_path, exist_ok=True)
+
+        self.index_to_source: Dict[int, str] = {}
+        self.index_to_tmp: Dict[int, str] = {}
+        self.frames: List[str] = []
+
+        self._prepare_frames()
+        self.duration = len(self.frames)
+        self.fps = None
+        self.width = None
+        self.height = None
+
+    def _prepare_frames(self) -> None:
+        existing = set(os.listdir(self.tmp_path))
+        if existing:
+            for name in sorted(existing):
+                try:
+                    idx = int(os.path.splitext(name)[0])
+                except ValueError:
+                    continue
+                self.frames.append(name)
+                self.index_to_tmp[idx] = name
+            if self.frames:
+                self.index_to_source = {
+                    idx: os.path.join(self.images_path, self.index_to_tmp[idx])
+                    for idx in self.index_to_tmp
+                    if os.path.exists(os.path.join(self.images_path, self.index_to_tmp[idx]))
+                }
+                self.frames.sort()
+                return
+
+        shutil.rmtree(self.tmp_path)
+        os.makedirs(self.tmp_path, exist_ok=True)
+
+        images = [
+            f for f in sorted(os.listdir(self.images_path))
+            if f.lower().endswith(self._VALID_EXT)
+        ]
+
+        if not images:
+            raise FileNotFoundError(f"No images found in {self.images_path}")
+
+        for idx, name in enumerate(images):
+            src = os.path.join(self.images_path, name)
+            ext = os.path.splitext(name)[1].lower() or ".jpg"
+            tmp_name = f"{idx:08d}{ext}"
+            dst = os.path.join(self.tmp_path, tmp_name)
+            shutil.copy2(src, dst)
+            self.frames.append(tmp_name)
+            self.index_to_source[idx] = src
+            self.index_to_tmp[idx] = tmp_name
+
+    def _frame_name(self, ind: int) -> Optional[str]:
+        if ind in self.index_to_tmp:
+            return self.index_to_tmp[ind]
+        name = f"{ind:08d}"
+        for candidate in self.frames:
+            if candidate.startswith(name):
+                self.index_to_tmp[ind] = candidate
+                return candidate
+        return None
+
+    def get_list_of_n_frames(self, n: int, start_frame: Optional[str] = None, end_frame: Optional[str] = None) -> List[str]:
+        if not self.frames or n <= 0:
+            return []
+
+        start_idx = self.frames.index(start_frame) if start_frame in self.frames else 0
+        end_idx = self.frames.index(end_frame) if end_frame in self.frames else len(self.frames) - 1
+
+        valid_frames = self.frames[start_idx:end_idx+1]
+        total_frames = len(valid_frames)
+
+        if n >= total_frames:
+            return [os.path.join(self.tmp_path, frame) for frame in valid_frames]
+
+        step = total_frames / n
+        indices = sorted(set(round(i * step) for i in range(n)))
+        selected_frames = [valid_frames[i] for i in indices if i < total_frames]
+        return [os.path.join(self.tmp_path, frame) for frame in selected_frames]
+
+    def extract_specific_frames(self, frame_indices: List[int], full_res: bool = False) -> None:
+        os.makedirs(self.output_dir, exist_ok=True)
+
+        for ind in frame_indices:
+            src = self.index_to_source.get(ind)
+            if src is None:
+                frame_name = self._frame_name(ind)
+                if frame_name is None:
+                    continue
+                candidate = os.path.join(self.images_path, frame_name)
+                if os.path.exists(candidate):
+                    src = candidate
+            if src is None:
+                continue
+            ext = os.path.splitext(src)[1] or ".jpg"
+            dst = os.path.join(self.output_dir, f"{ind:08d}{ext}")
+            shutil.copy2(src, dst)
+
+    def ind_to_frame_name(self, ind: int) -> str:
+        frame = self._frame_name(ind)
+        if frame is None:
+            frame = f"{ind:08d}.jpg"
+        return os.path.join(self.tmp_path, frame)
+
+    def get_frames_between_pairs(self, peak_pairs: List[tuple], n: int) -> List[str]:
+        selected_frames: List[str] = []
+        for p1, p2 in peak_pairs:
+            frame1 = self._frame_name(p1) if isinstance(p1, int) else p1
+            frame2 = self._frame_name(p2) if isinstance(p2, int) else p2
+            if frame1 in self.frames and frame2 in self.frames:
+                selected_frames.extend(
+                    self.get_list_of_n_frames(n, start_frame=frame1, end_frame=frame2)
+                )
         return selected_frames


### PR DESCRIPTION
## Summary
- add a --images_path option to do_all.py to allow running the pipeline on pre-extracted frames
- teach the preprocessing COLMAP pipeline to work with image folders by introducing an ImageFolderWrapper
- propagate the new option through preprocessing entry points and adjust cleanup utilities for non-video inputs

## Testing
- python -m compileall do_all.py preprocess

------
https://chatgpt.com/codex/tasks/task_e_6907cc1d96ac832aaa3582574cfa74cc